### PR TITLE
[FE] onError 콜백 함수 2번 호출 에러 해결

### DIFF
--- a/client/src/common/components/Header.tsx
+++ b/client/src/common/components/Header.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
 import { useDispatch } from 'react-redux';
 import Modal from 'react-modal';
-import {useQueryClient} from 'react-query';
+import { useQueryClient } from 'react-query';
 
 import { FaArrowRightFromBracket } from 'react-icons/fa6';
 import { HiMiniXMark } from 'react-icons/hi2';
@@ -31,8 +31,6 @@ export default function Header() {
 
   const queryClient = useQueryClient();
 
-  const { myData } = useMyInfo();
-
   const token = localStorage.getItem('Authorization');
 
   const kakaoLink = `${BASE_URL}/oauth2/authorization/kakao`;
@@ -40,6 +38,20 @@ export default function Header() {
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  const { myData, error } = useMyInfo();
+
+  if (error) {
+    console.log(error);
+    if (error.response?.status === 401 && token) {
+      navigate('/');
+      localStorage.clear();
+      queryClient.clear();
+      alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
+    } else {
+      console.error('오류가 발생했습니다.', error.message);
+    }
+  }
 
   const logoutPostMutaion = useMutation(
     () => {

--- a/client/src/common/util/customHook/useMyInfo.tsx
+++ b/client/src/common/util/customHook/useMyInfo.tsx
@@ -1,15 +1,12 @@
-import { useQuery,useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 
 import { getData } from '../../apis';
 import { BASE_URL } from '../constantValue';
 import { Member } from '../../type';
 
 export default function useMyInfo() {
-  const navigate = useNavigate();
   const token = localStorage.getItem('Authorization');
-  const queryClient = useQueryClient();
   const {
     data: myData,
     isLoading,
@@ -19,16 +16,6 @@ export default function useMyInfo() {
     () => getData(`${BASE_URL}/members/userInfo`),
     {
       enabled: !!token,
-      onError: (error) => {
-        if (error.response?.status === 401 && token) {
-          navigate('/');
-          localStorage.clear();
-          queryClient.clear();
-          alert('토큰이 만료되었습니다. 다시 로그인해주세요.');
-        } else {
-          console.error('오류가 발생했습니다.', error.message);
-        }
-      },
       staleTime: 30 * 60 * 1000,
       cacheTime: 30 * 60 * 1000,
     },


### PR DESCRIPTION
✅ 같은 queryKey를 가진 훅 한 페이지에 2번 사용으로 인해 콜백함수 2번 실행됨
✅ onError 콜백함수 대신 어느 페이지에나 있는 헤더컴포넌트 단에서 리턴된 error 사용으로 토큰만료시 로그아웃 처리 한번만 되게 고침