### PR TITLE
[FE] 페이지 이동시 스크롤 고정되는 문제 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,8 @@ import { GlobalStyle } from './common/style';
 import Header from './common/components/Header';
 import Footer from './common/components/Footer';
 import ChatModal from './common/components/Chat/views/ChatModal';
+import ScrllToTopInstant from './common/components/ScrollToTopInstant';
+
 import { AUTHORIZATION } from './common/util/constantValue';
 
 Quill.register('modules/imageResize', ImageResize);
@@ -14,7 +16,7 @@ Quill.register('modules/imageResize', ImageResize);
 export default function App() {
   const location = useLocation();
   const token: string | null = localStorage.getItem(AUTHORIZATION);
-
+  <ScrllToTopInstant />;
   return (
     <>
       <GlobalStyle />

--- a/client/src/common/components/Header.tsx
+++ b/client/src/common/components/Header.tsx
@@ -95,7 +95,7 @@ export default function Header() {
 
   return (
     <Head>
-      <Link to="/lists">
+      <a href="/lists">
         <Logo>
           <img src={logo} alt="로고이미지" style={{ height: '39px' }} />
           <HoverImage
@@ -104,7 +104,7 @@ export default function Header() {
             style={{ height: '39px' }}
           />
         </Logo>
-      </Link>
+      </a>
       {token ? (
         <MenuContainer>
           <UserContainer className="margin-left" onClick={handleMyProfile}>

--- a/client/src/common/components/ScrollToTopInstant.tsx
+++ b/client/src/common/components/ScrollToTopInstant.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrllToTopInstant() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    if (pathname !== "/lists") {
+      window.scrollTo(0, 0);
+    }
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
1. 페이지 이동시 스크롤이 고정되는 문제가 있었습니다. useEffect로 pathname 변경시 scroll 이 최상단으로 갈 수 있도록 컴포넌트를 생성하여 App 컴포넌트의 하위 컴포넌트로 넣어주었습니다. 
2. '/lists' 페이지는 유저가 스크롤 중간에 상세페이지로 넘어갔다가 돌아갈 수 있기 때문에 제외했습니다.
3. UX상 로고 버튼을 누르면 페이지 최상단이 보이는게 자연스러울것 같아 a 태그로 변경했습니다.