### PR TITLE
[FE] 유저이미지 수정후 쿼리무효화

### DIFF
--- a/client/src/pages/UserEdit/views/UserEdit.tsx
+++ b/client/src/pages/UserEdit/views/UserEdit.tsx
@@ -91,7 +91,7 @@ export default function UserEdit() {
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries('userInfo');
+          queryClient.invalidateQueries('myInfo');
           navigate(`/user/${myData?.memberId}`);
         },
         onError: (error) => {


### PR DESCRIPTION
1. 유저 프로필 사진 변경 후 navigate 되었을때 새로고침을 해야만 사진 반영되는 문제를 react-query의 쿼리 무효화를 통해 바로 바뀐 데이터를 들고오게 수정하였습니다.