### PR TITLE
[FE] 글 삭제 데이터 캐싱

### DIFF
--- a/client/src/common/components/Card.tsx
+++ b/client/src/common/components/Card.tsx
@@ -32,7 +32,7 @@ export default function Card({
       <Content>
         <div className="title">{title}</div>
         <div className="content">
-          {content.length >= 57 ? `${content?.slice(0, 57)}...` : content}
+          {content.length >= 50 ? `${content?.slice(0, 50)}...` : content}
         </div>
       </Content>
       <TagSection>

--- a/client/src/pages/Details/views/Details.tsx
+++ b/client/src/pages/Details/views/Details.tsx
@@ -33,6 +33,10 @@ export default function Details() {
         : `${BASE_URL}/posts/${id}`;
       return getData(url);
     },
+    {
+      staleTime: Infinity,
+      cacheTime: Infinity,
+    },
   );
 
   const locationData = {
@@ -108,6 +112,11 @@ const TitleWrapper = styled.div`
 
   > .link {
     cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+      text-underline-offset: 10px;
+      text-decoration-thickness: 4px;
+    }
   }
 
   & h1 {

--- a/client/src/pages/User/views/User.tsx
+++ b/client/src/pages/User/views/User.tsx
@@ -24,7 +24,7 @@ export default function User() {
 
   const token: string | null = localStorage.getItem(AUTHORIZATION);
 
-  const { myData } = useMyInfo();
+  const { myData, error } = useMyInfo();
 
   const isMine = memberId === String(myData?.memberId);
 
@@ -55,6 +55,12 @@ export default function User() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  if(error){
+    console.log(error)
+    alert('찾을 수 없는 회원입니다!');
+    navigate(-1);
+  }
+
   const profileData = userInfo || myData;
 
   return (
@@ -81,7 +87,7 @@ export default function User() {
                       <ProfileItem style={{ display: 'flex' }}>
                         <LocationIcon />
                         &nbsp;
-                        <div>{`${profileData.location.city} ${profileData.location.province}`}</div>
+                        <div>{profileData.location ? `${profileData.location.city} ${profileData.location.province}`: "미설정"}</div>
                       </ProfileItem>
                       <ProfileItem>
                         {profileData.isMale ? `남자` : `여자`}

--- a/client/src/pages/UserEdit/views/UserEdit.tsx
+++ b/client/src/pages/UserEdit/views/UserEdit.tsx
@@ -61,7 +61,7 @@ export default function UserEdit() {
 
   const handleImgChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const input = event.target;
-    if (input.files && input.files[0]) {
+    if (input.files) {
       const file = input.files[0]; // 파일 추출
 
       const reader = new FileReader();

--- a/client/src/pages/Write,Edit/components/Form.tsx
+++ b/client/src/pages/Write,Edit/components/Form.tsx
@@ -10,7 +10,7 @@ import {
   UPDATE,
 } from '../../../common/util/constantValue';
 import { ChangeEvent, useEffect } from 'react';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 import LocationSelector from '../../../common/components/LocationSelector';
@@ -30,6 +30,8 @@ export default function Form() {
   const navigate = useNavigate();
 
   const dispatch = useDispatch();
+
+  const queryClient = useQueryClient();
 
   const { id } = useParams();
 
@@ -81,6 +83,7 @@ export default function Form() {
     if (id) {
       patchMutation.mutate(data, {
         onSuccess: () => {
+          queryClient.invalidateQueries('getData');
           navigate(`/details/${id}`);
         },
       });


### PR DESCRIPTION
1. 글 상세 데이터를 실시간으로 업데이트 할 필요 없다고 판단하여 데이터를 캐싱해두고 불필요한 api 호출을 막았습니다. 
2.글 수정시에는 쿼리를 무효화하여 데이터를 새로 받아와 업데이트 되게 하였습니다.
3. 폰트 변경 후 카드 컴포넌트에 글 내용이 길어질 시 카드 컴포넌트 안 UI 구조가 깨지는 현상이 있었습니다. 글자수를 줄여 일관되게 만들었습니다.